### PR TITLE
Fixed various minor flaws when running cron

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,10 @@
 FROM python:3.8.2-buster
 
+ENV DB_HOST postgresql
+ENV DB_USER postgres
+ENV DB_PASSWORD secret
+ENV DB_NAME postgres
+
 WORKDIR /usr/helpradar
 RUN apt-get update && apt-get install -yq cron
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,6 +4,10 @@ services:
 
   app:
     build: .
+    networks:
+      - helpradar
+    depends_on:
+      - postgresql
     volumes:
       - ./src:/usr/helpradar
     environment:
@@ -14,6 +18,8 @@ services:
 
   postgresql:
     image: postgres:12.2-alpine
+    networks:
+      - helpradar
     volumes:
       - postgresql:/var/lib/postgresql
     environment:
@@ -21,3 +27,7 @@ services:
 
 volumes:
   postgresql: {}
+
+networks:
+  helpradar:
+    driver: bridge

--- a/src/docker-entrypoint.sh
+++ b/src/docker-entrypoint.sh
@@ -1,4 +1,30 @@
 #!/bin/bash
 export PATH="/usr/local/bin:/usr/bin:/bin"
+# make sure cron has access to the environment variables
+. <(xargs -0 bash -c 'printf "export %q\n" "$@"' -- < /proc/1/environ)
+
+function fail {
+  echo $1 >&2
+  exit 1
+}
+
+function retry {
+  local n=1
+  local max=5
+  local delay=15
+  while true; do
+    "$@" && break || {
+      if [[ $n -lt $max ]]; then
+        ((n++))
+        echo "Command failed. Attempt $n/$max:"
+        sleep $delay;
+      else
+        fail "The command has failed after $n attempts."
+      fi
+    }
+  done
+}
+
 cd /usr/helpradar
-alembic upgrade head
+# Alembic connection will be retried 5 times when necessary. This is needed because docker-compose doesn't wait for postgres to start
+retry alembic upgrade head


### PR DESCRIPTION
There where various little issues regarding cron:

* Cron does not know about PATH. We need to tell it where to find alembic
* Cron does not know about ENV variables, we need to tell it
* When running `docker-compose up` the database is not completely ready when the app container starts. This caused the alembic cronjob to fail. Built in a function to retry the connection 5 times (max)